### PR TITLE
:recycle: QueryDSL를 도입해 게시글 조회 기능 리팩토링 (#36)

### DIFF
--- a/src/main/java/com/example/carefully/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/carefully/domain/post/controller/PostController.java
@@ -43,7 +43,7 @@ public class PostController {
     @GetMapping
     public ResponseEntity<BaseResponse<SliceDto<SearchResponse>>> searchPostList(@RequestParam("role") String postRole,
                                                                                  @RequestParam(value = "category", required = false) Long categoryId,
-                                                                                 @PageableDefault(size = 2) Pageable pageable) {
+                                                                                 @PageableDefault(size = 100) Pageable pageable) {
         return ResponseEntity.ok(BaseResponse.create(
                 GET_POST_LIST_SUCCESS.getMessage(), postService.searchPostList(postRole, categoryId, pageable)));
     }

--- a/src/main/java/com/example/carefully/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/carefully/domain/post/controller/PostController.java
@@ -43,7 +43,7 @@ public class PostController {
     @GetMapping
     public ResponseEntity<BaseResponse<SliceDto<SearchResponse>>> searchPostList(@RequestParam("role") String postRole,
                                                                                  @RequestParam(value = "category", required = false) Long categoryId,
-                                                                                 @PageableDefault(size = 100) Pageable pageable) {
+                                                                                 @PageableDefault(size = 2) Pageable pageable) {
         return ResponseEntity.ok(BaseResponse.create(
                 GET_POST_LIST_SUCCESS.getMessage(), postService.searchPostList(postRole, categoryId, pageable)));
     }

--- a/src/main/java/com/example/carefully/domain/post/repository/CustomPostRepository.java
+++ b/src/main/java/com/example/carefully/domain/post/repository/CustomPostRepository.java
@@ -1,0 +1,51 @@
+package com.example.carefully.domain.post.repository;
+
+import com.example.carefully.domain.post.domain.Post;
+import com.example.carefully.domain.post.domain.PostRole;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.example.carefully.domain.post.domain.QPost.post;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomPostRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public Slice<Post> getPostList(Pageable pageable, PostRole postRole, Long categoryId) {
+        List<Post> posts = queryFactory.selectFrom(post)
+                .where(postRoleEq(postRole), categoryEq(categoryId))
+                .orderBy(post.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        return new SliceImpl<>(posts, pageable, hasNext(posts, pageable));
+    }
+
+    private boolean hasNext(List<Post> content, Pageable pageable) {
+        if (content.size() > pageable.getPageSize()) {
+            content.remove(pageable.getPageSize());
+            return true;
+        }
+        return false;
+    }
+
+    private BooleanExpression postRoleEq(PostRole postRole) {
+        return post.postRole.eq(postRole);
+    }
+
+    private BooleanExpression categoryEq(Long category) {
+        if (category == null) {
+            return null;
+        }
+        return post.category.id.eq(category);
+    }
+}

--- a/src/main/java/com/example/carefully/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/carefully/domain/post/service/PostServiceImpl.java
@@ -7,6 +7,7 @@ import com.example.carefully.domain.post.dto.PostDto;
 import com.example.carefully.domain.category.exception.CategoryEmptyException;
 import com.example.carefully.domain.post.exception.PostEmptyException;
 import com.example.carefully.domain.category.repository.CategoryRepository;
+import com.example.carefully.domain.post.repository.CustomPostRepository;
 import com.example.carefully.domain.post.repository.PostRepository;
 import com.example.carefully.global.dto.SliceDto;
 import com.example.carefully.infra.s3.S3Service;
@@ -23,6 +24,7 @@ public class PostServiceImpl implements PostService {
     private final S3Service s3Service;
     private final PostRepository postRepository;
     private final CategoryRepository categoryRepository;
+    private final CustomPostRepository customPostRepository;
     private final Long tempUserId = 1L;
 
     @Override
@@ -66,18 +68,10 @@ public class PostServiceImpl implements PostService {
     public SliceDto<PostDto.SearchResponse> searchPostList(String postRole,
                                                            Long categoryId,
                                                            Pageable pageable) {
-        Slice<PostDto.SearchResponse> searchListByPostRole = getSearchListByPostRole(postRole, categoryId, pageable);
-        return SliceDto.create(searchListByPostRole);
-    }
-
-    private Slice<PostDto.SearchResponse> getSearchListByPostRole(String postRole, Long categoryId, Pageable pageable) {
-        if (PostRole.isFree(postRole)) {
-            return postRepository.findAllByPostRoleAndCategoryIdOrderByCreatedAtDesc(
-                    pageable,
-                    PostRole.valueOf(postRole),
-                    categoryId).map(PostDto.SearchResponse::create);
-        }
-        return postRepository.findAllByPostRoleOrderByCreatedAtDesc(pageable, PostRole.valueOf(postRole))
+        Slice<PostDto.SearchResponse> postsByRole = customPostRepository
+                .getPostList(pageable, PostRole.valueOf(postRole), categoryId)
                 .map(PostDto.SearchResponse::create);
+
+        return SliceDto.create(postsByRole);
     }
 }

--- a/src/main/java/com/example/carefully/domain/post/service/QuestionServiceImpl.java
+++ b/src/main/java/com/example/carefully/domain/post/service/QuestionServiceImpl.java
@@ -4,6 +4,7 @@ import com.example.carefully.domain.post.domain.Post;
 import com.example.carefully.domain.post.domain.PostRole;
 import com.example.carefully.domain.post.dto.QuestionDto;
 import com.example.carefully.domain.post.exception.PostEmptyException;
+import com.example.carefully.domain.post.repository.CustomPostRepository;
 import com.example.carefully.domain.post.repository.PostRepository;
 import com.example.carefully.global.dto.SliceDto;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class QuestionServiceImpl implements QuestionService {
 
     private final PostRepository postRepository;
+    private final CustomPostRepository customPostRepository;
     private final Long tempUserId = 1L;
 
     @Override
@@ -42,9 +44,8 @@ public class QuestionServiceImpl implements QuestionService {
 
     @Override
     public SliceDto<QuestionDto.SearchResponse> searchQuestionList(Pageable pageable) {
-        Slice<QuestionDto.SearchResponse> sliceDto = postRepository.findAllByPostRoleOrderByCreatedAtDesc(pageable, PostRole.QUEST)
+        Slice<QuestionDto.SearchResponse> sliceDto = customPostRepository.getPostList(pageable, PostRole.QUEST, null)
                 .map(QuestionDto.SearchResponse::create);
-
         return SliceDto.create(sliceDto);
     }
 


### PR DESCRIPTION
## 📚 개요
+ #36 

## ✏️ 작업 내용
+ DataJPA에서 QueryDSL로 자유/공지/문의 조회 메서드 변경

## 💡 주의 사항

