### PR TITLE
:sparkles: AOP로 요청 로그 남기는 기능 구현 (#59)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
     implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
 
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/carefully/domain/category/domain/Category.java
+++ b/src/main/java/com/example/carefully/domain/category/domain/Category.java
@@ -5,6 +5,7 @@ import com.example.carefully.domain.user.entity.Role;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -14,6 +15,7 @@ import java.util.NoSuchElementException;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Slf4j
 public class Category {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,7 +40,7 @@ public class Category {
             Role categoryRole = Role.of(name);
             return categoryRole.isPaidRole();
         } catch (NoSuchElementException ex) {
-            ex.printStackTrace();
+            log.info("categoryId={} name={} 유료 회원 카테고리가 아닌 자유 카테고리 요청입니다.", id, name);
             return false;
         }
     }

--- a/src/main/java/com/example/carefully/global/aop/RequestLogAspect.java
+++ b/src/main/java/com/example/carefully/global/aop/RequestLogAspect.java
@@ -1,0 +1,18 @@
+package com.example.carefully.global.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Slf4j
+@Component
+public class RequestLogAspect {
+
+    @Before("com.example.carefully.global.aop.pointcut.Pointcuts.allController()")
+    public void doLog(JoinPoint joinPoint) {
+        log.info("[trace] request={} args={}", joinPoint.getSignature(), joinPoint.getArgs());
+    }
+}

--- a/src/main/java/com/example/carefully/global/aop/pointcut/Pointcuts.java
+++ b/src/main/java/com/example/carefully/global/aop/pointcut/Pointcuts.java
@@ -1,0 +1,9 @@
+package com.example.carefully.global.aop.pointcut;
+
+import org.aspectj.lang.annotation.Pointcut;
+
+public class Pointcuts {
+
+    @Pointcut("execution(* com.example.carefully.domain..*Controller*.*(..))")
+    public void allController() {}
+}


### PR DESCRIPTION
## 📚 개요
+ #59 

## ✏️ 작업 내용
+ 프론트와 연동할 때 어떤 요청에서 에러가 났는지 보기 편하도록 HTTP 요청 로그 남겼습니다.
+ `e.printStackTrace`에 단점이 있는지 처음 알아서 `@Slf4j`로 카테고리쪽 예외 로그 변경했습니다.

## 💡 주의 사항
+ `sql` 문도 배포 서버에서는 로그를 안남기도록 바꿔야 하는데 확인해볼게 있어서 나중에 지우겠습니다!